### PR TITLE
Change Payload from a trait to a struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,6 @@
 version = 4
 
 [[package]]
-name = "bytemuck"
-version = "1.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
-
-[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,7 +33,6 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 name = "orbipacket"
 version = "0.1.0"
 dependencies = [
- "bytemuck",
  "bytes",
  "corncobs",
  "crc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Levi Gomes", "The OrbiSat Oeiras Team"]
 description = "A packet based protocol for communication with CanSat devices."
 
 [dependencies]
-bytemuck = "1.22.0"
 bytes = { version = "1.10.1", default-features = false }
 corncobs = "0.1.3"
 crc = "3.2.1"

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -49,3 +49,23 @@ impl Payload {
         &self.0[..=last_non_zero]
     }
 }
+
+impl Default for Payload {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&[u8]> for Payload {
+    type Error = PayloadError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        Self::from_bytes(value)
+    }
+}
+
+impl AsRef<[u8]> for Payload {
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}


### PR DESCRIPTION
The `Payload` trait, despite looking good on paper and integrating seamlessly into the crate structure, is very unergonomic for the end-user: it makes all packet types generic, meaning it is impossible to have any sort of polymorphism (`dyn` trait objects don't work either because of bytemuck's constraints). Thus, it was changed to a struct which holds a byte slice. This means the end-user is responsible for converting the actual payload to/from the raw bytes, which is a small cost for a much friendlier interface overall.