### PR TITLE
Decrease size of timestamps to 5 bytes

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -67,7 +67,7 @@ impl Packet {
         }
 
         let found_payload_len = buf[1] as usize;
-        let expected_payload_len = len - 13;
+        let expected_payload_len = len - InternalPacket::OVERHEAD;
         if found_payload_len != expected_payload_len {
             return Err(DecodeError::InvalidLength {
                 expected: expected_payload_len,

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -88,16 +88,15 @@ impl Packet {
         let tmtc = (buf[2] & 1 << 7) == 0;
         let id = (buf[2] & 0b01111100) >> 2;
         // A range can't be used here because from_le_bytes expects a [u8; 8]
-        let timestamp = u64::from_le_bytes([
-            buf[3], buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10],
-        ]);
+        let timestamp = u64::from_le_bytes([buf[3], buf[4], buf[5], buf[6], buf[7], 0, 0, 0]);
 
         let packet = InternalPacket::new(
             id.try_into()?,
-            Timestamp::new(timestamp),
+            // Unwrapping is safe here because we just created the value from 5 bytes
+            Timestamp::new(timestamp).unwrap(),
             // Unwrapping is safe here because found_payload_len is at most 255, so the slice
             // is never too long for Payload
-            Payload::from_raw_bytes(&buf[11..][..found_payload_len]).unwrap(),
+            Payload::from_raw_bytes(&buf[8..][..found_payload_len]).unwrap(),
         );
 
         Ok(if tmtc {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -140,7 +140,8 @@ mod test {
     #[test]
     fn tm_packet_decode_works() {
         let mut buf = [
-            5, VERSION, 4, 4, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 28, 228, 0,
+            0x05, VERSION, 0x04, 0x04, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03, 0x7e,
+            0x12, 0,
         ];
 
         let packet = Packet::decode_single(&mut buf).unwrap();
@@ -156,7 +157,8 @@ mod test {
     #[test]
     fn tc_packet_decode_works() {
         let mut buf = [
-            5, VERSION, 4, 132, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 12, 95, 0,
+            0x05, VERSION, 0x04, 0x84, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03, 0x014,
+            0x022, 0,
         ];
 
         let packet = Packet::decode_single(&mut buf).unwrap();

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -41,7 +41,7 @@ impl Packet {
     /// use orbipacket::{Packet, DeviceId};
     ///
     /// let mut buf = [
-    ///     5, 1, 4, 4, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 28, 228, 0,
+    ///     0x05, 1, 0x04, 0x04, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03, 0x7e, 0x12, 0,
     /// ];
     ///
     /// let packet = Packet::decode_single(&mut buf)?;

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -44,9 +44,9 @@ impl InternalPacket {
         buffer[idx] = control;
         idx += 1;
 
-        buffer[idx..idx + 8].copy_from_slice(&self.timestamp().get().to_le_bytes());
+        buffer[idx..idx + 5].copy_from_slice(&self.timestamp().get().to_le_bytes()[..5]);
 
-        idx + 8
+        idx + 5
     }
 
     /// Write the payload data into the provided buffer

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -202,7 +202,10 @@ mod tests {
 
         assert_eq!(
             encoded,
-            &[5, VERSION, 4, 4, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 28, 228, 0][..]
+            &[
+                0x05, VERSION, 0x04, 0x04, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03,
+                0x7e, 0x12, 0x00
+            ][..]
         );
     }
 
@@ -217,7 +220,10 @@ mod tests {
 
         assert_eq!(
             encoded,
-            &[5, VERSION, 4, 132, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 12, 95, 0][..]
+            &[
+                0x05, VERSION, 0x04, 0x84, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03,
+                0x14, 0x22, 0
+            ][..]
         );
     }
 
@@ -252,7 +258,10 @@ mod tests {
 
         assert_eq!(
             encoded,
-            &[5, VERSION, 4, 4, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 28, 228, 0][..]
+            &[
+                0x05, VERSION, 0x04, 0x04, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03,
+                0x7e, 0x12, 0x00
+            ][..]
         );
     }
 
@@ -267,7 +276,10 @@ mod tests {
 
         assert_eq!(
             encoded,
-            &[5, VERSION, 4, 132, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 12, 95, 0][..]
+            &[
+                0x05, VERSION, 0x04, 0x84, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03,
+                0x14, 0x22, 0
+            ][..]
         );
     }
 
@@ -282,7 +294,10 @@ mod tests {
 
         assert_eq!(
             encoded,
-            &[5, VERSION, 4, 4, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 28, 228, 0][..]
+            &[
+                0x05, VERSION, 0x04, 0x04, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03,
+                0x7e, 0x12, 0x00
+            ][..]
         );
     }
 
@@ -297,7 +312,10 @@ mod tests {
 
         assert_eq!(
             encoded,
-            &[5, VERSION, 4, 132, 10, 1, 1, 1, 1, 1, 1, 4, 0xEF, 0xCD, 0xAB, 3, 12, 95, 0][..]
+            &[
+                0x05, VERSION, 0x04, 0x84, 0x0a, 0x01, 0x01, 0x01, 0x04, 0xEF, 0xCD, 0xAB, 0x03,
+                0x14, 0x22, 0
+            ][..]
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,14 +33,14 @@
 //!
 //! let packet = TmPacket::new(
 //!     DeviceId::System,
-//!     Timestamp::new(1234),
+//!     Timestamp::new(0x1234)?,
 //!     Payload::from_raw_bytes(b"hello world")?,
 //! );
 //! let mut buffer = [1u8; 500];
 //!
 //! let encoded = packet.encode(&mut buffer)?;
 //!
-//! assert_eq!(encoded, &[6, 0x01, 11, 4, 0xD2, 0x04, 1, 1, 1, 1, 1, 14, b'h', b'e', b'l', b'l', b'o', b' ', b'w', b'o', b'r', b'l', b'd', 223, 75, 0][..]);
+//! assert!(matches!(encoded, [0x06, 0x01, 0x0b, 0x04, 0x34, 0x12, 0x01, 0x01, 0x0E, b'h', b'e', b'l', b'l', b'o', b' ', b'w', b'o', b'r', b'l', b'd', _, _, 0]));
 //! assert_eq!(encoded.len(), packet.encoded_size());
 //! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
@@ -55,13 +55,13 @@
 //! for i in 1..10u8 {
 //!     let packet = TmPacket::new(
 //!         DeviceId::System,
-//!         Timestamp::new(1234),
+//!         Timestamp::new(0x1111)?,
 //!         Payload::from_raw_bytes([i])?,
 //!     );
 //!
 //!     let encoded = packet.encode(&mut buffer)?;
 //!
-//!     assert!(matches!(encoded, [6, 0x01, 1, 4, 210, 4, 1, 1, 1, 1, 1, 4, i, _, _, 0]));
+//!     assert!(matches!(encoded, [0x06, 0x01, 0x01, 0x04, 0x11, 0x11, 0x01, 0x01, 0x04, i, _, _, 0]));
 //!     assert_eq!(encoded.len(), packet.encoded_size());
 //! }
 //! # Ok::<(), Box<dyn std::error::Error>>(())
@@ -173,8 +173,9 @@ impl InternalPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TmPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
+    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
     /// assert_eq!(*packet.device_id(), DeviceId::System);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     fn device_id(&self) -> &DeviceId {
         &self.device_id
@@ -185,8 +186,9 @@ impl InternalPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TmPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
-    /// assert_eq!(*packet.timestamp(), Timestamp::new(0));
+    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
+    /// assert_eq!(*packet.timestamp(), Timestamp::new(0)?);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     fn timestamp(&self) -> &Timestamp {
         &self.timestamp
@@ -197,8 +199,9 @@ impl InternalPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TmPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
+    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
     /// assert_eq!(*packet.payload(), Payload::new());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     fn payload(&self) -> &Payload {
         &self.payload
@@ -264,8 +267,9 @@ impl TmPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TmPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
+    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
     /// assert_eq!(*packet.device_id(), DeviceId::System);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn device_id(&self) -> &DeviceId {
         self.0.device_id()
@@ -276,8 +280,9 @@ impl TmPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TmPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
-    /// assert_eq!(*packet.timestamp(), Timestamp::new(0));
+    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
+    /// assert_eq!(*packet.timestamp(), Timestamp::new(0)?);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn timestamp(&self) -> &Timestamp {
         self.0.timestamp()
@@ -288,8 +293,9 @@ impl TmPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TmPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
+    /// let packet = TmPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
     /// assert_eq!(*packet.payload(), Payload::new());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn payload(&self) -> &Payload {
         self.0.payload()
@@ -366,8 +372,9 @@ impl TcPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TcPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TcPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
-    /// assert_eq!(*packet.timestamp(), Timestamp::new(0));
+    /// let packet = TcPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
+    /// assert_eq!(*packet.timestamp(), Timestamp::new(0)?);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn timestamp(&self) -> &Timestamp {
         self.0.timestamp()
@@ -378,8 +385,9 @@ impl TcPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TcPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TcPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
+    /// let packet = TcPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
     /// assert_eq!(*packet.device_id(), DeviceId::System);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn device_id(&self) -> &DeviceId {
         self.0.device_id()
@@ -390,8 +398,9 @@ impl TcPacket {
     /// # Example
     /// ```
     /// # use orbipacket::{TcPacket, DeviceId, Timestamp, Payload};
-    /// let packet = TcPacket::new(DeviceId::System, Timestamp::new(0), Payload::new());
+    /// let packet = TcPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new());
     /// assert_eq!(*packet.payload(), Payload::new());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn payload(&self) -> &Payload {
         self.0.payload()
@@ -458,11 +467,12 @@ impl Packet {
     /// # Examples
     /// ```
     /// # use orbipacket::{Packet, TmPacket, TcPacket, DeviceId, Timestamp, Payload};
-    /// let packet = Packet::TmPacket(TmPacket::new(DeviceId::System, Timestamp::new(0), Payload::new()));
+    /// let packet = Packet::TmPacket(TmPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new()));
     /// assert_eq!(packet.is_tm_packet(), true);
     ///
-    /// let packet = Packet::TcPacket(TcPacket::new(DeviceId::System, Timestamp::new(0), Payload::new()));
+    /// let packet = Packet::TcPacket(TcPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new()));
     /// assert_eq!(packet.is_tm_packet(), false);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn is_tm_packet(&self) -> bool {
         matches!(self, Packet::TmPacket(_))
@@ -473,11 +483,12 @@ impl Packet {
     /// # Examples
     /// ```
     /// # use orbipacket::{Packet, TmPacket, TcPacket, DeviceId, Timestamp, Payload};
-    /// let packet = Packet::TmPacket(TmPacket::new(DeviceId::System, Timestamp::new(0), Payload::new()));
+    /// let packet = Packet::TmPacket(TmPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new()));
     /// assert_eq!(packet.is_tc_packet(), false);
     ///
-    /// let packet = Packet::TcPacket(TcPacket::new(DeviceId::System, Timestamp::new(0), Payload::new()));
+    /// let packet = Packet::TcPacket(TcPacket::new(DeviceId::System, Timestamp::new(0)?, Payload::new()));
     /// assert_eq!(packet.is_tc_packet(), true);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn is_tc_packet(&self) -> bool {
         matches!(self, Packet::TcPacket(_))
@@ -513,12 +524,12 @@ mod tests {
 
     #[test]
     fn tm_packet_overhead_returns_correct() {
-        assert_eq!(TmPacket::OVERHEAD, 13);
+        assert_eq!(TmPacket::OVERHEAD, 10);
     }
 
     #[test]
     fn tm_packet_size_returns_size_of_packet() {
-        assert_eq!(TmPacket::MAX_ENCODED_SIZE, 15 + 256);
+        assert_eq!(TmPacket::MAX_ENCODED_SIZE, 10 + 2 + 256);
     }
 
     #[test]


### PR DESCRIPTION
In line with the changes introduced by [#10 in orbipacket](https://github.com/orbisat-oeiras/orbipacket/pull/10), this PR reduces timestamps to 5 bytes.